### PR TITLE
Add PGHOST variable again

### DIFF
--- a/templates/default/bash_it/custom/exports.bash
+++ b/templates/default/bash_it/custom/exports.bash
@@ -20,6 +20,8 @@ shopt -s histappend                      # append to history, don't overwrite it
 # Save and reload the history after each command finishes
 export PROMPT_COMMAND="history -a; history -c; history -r; echo -ne \"\033]0;${USER}@${HOSTNAME}\007\"; $PROMPT_COMMAND"
 
+export PGHOST=/var/run/postgresql/
+
 # no ._ files in archives please
 export COPYFILE_DISABLE=true
 


### PR DESCRIPTION
This fixes the following error when executing psql on OSX

```
psql: could not connect to server: No such file or directory
    Is the server running locally and accepting
    connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
```
