### PR TITLE
add root_ssh_agent to clone kdeploy

### DIFF
--- a/recipes/kdeploy.rb
+++ b/recipes/kdeploy.rb
@@ -1,4 +1,7 @@
 include_recipe 'applications::git'
+include_recipe "root_ssh_agent::env_keep"
+include_recipe "root_ssh_agent::ppid"
+
 if platform?('mac_os_x')
     include_recipe 'osxdefaults::finder_unhide_home'
 elsif platform_family?('debian')


### PR DESCRIPTION
Fix the problem when you clone kdeploy as root. Root now uses the keys from the user that started chef
