### PR TITLE
Setting enable_checkout to false

### DIFF
--- a/recipes/projects.rb
+++ b/recipes/projects.rb
@@ -11,6 +11,7 @@ node['dotfiles']['projects'].each do |folder, repo|
     git "#{node['etc']['passwd'][node['current_user']]['dir']}/#{node['dotfiles']['project_dir']}/#{folder}" do
         repository repo
         enable_submodules true
+        enable_checkout false
         action :checkout
         user node['current_user']
     end


### PR DESCRIPTION
This will make it so it clones to the default branch and doesn't checkout to a `deploy` branch. https://github.com/opscode/chef/blob/master/lib/chef/provider/git.rb#L79
