### PR TITLE
Allow selection of vim colour schemes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
-script: "gem install foodcritic && foodcritic -f any -f ~FC040 ."
+script: "gem install foodcritic && foodcritic -f any ."
 rvm:
   - 1.9.3

--- a/attributes/vim.rb
+++ b/attributes/vim.rb
@@ -8,3 +8,11 @@ node.default["dotfiles"]["vim"]["bundle"] = [
   {"syntastic" => "git://github.com/scrooloose/syntastic.git"},
   {"nerdtree" => "https://github.com/scrooloose/nerdtree.git"}
 ]
+
+node.default["dotfiles"]["vim"]["colors"] = [
+  {"Tomorrow-Night-Eighties" => "https://raw.githubusercontent.com/chriskempson/tomorrow-theme/master/vim/colors/Tomorrow-Night-Eighties.vim"},
+  {"base16-ocean" => "https://raw.githubusercontent.com/chriskempson/base16-vim/master/colors/base16-ocean.vim"},
+  {"solarized" => "https://raw.githubusercontent.com/altercation/solarized/master/vim-colors-solarized/colors/solarized.vim"}
+]
+
+node.default["dotfiles"]["vim"]["vimrc"]["colorscheme"] = "Tomorrow-Night-Eighties"

--- a/recipes/vim.rb
+++ b/recipes/vim.rb
@@ -26,21 +26,20 @@ node['dotfiles']['vimusers'].each do |username|
     action :create_if_missing
   end
 
-  node['dotfiles']['vim'].each do |folder, repohash|
-    directory "#{homepath.call}/.vim/#{folder}" do
-      owner username
-      mode 00755
-      recursive true
-    end
-    repohash.each do |repos|
-      repos.each do |repo|
-        git "#{homepath.call}/.vim/#{folder}/#{repo[0]}" do
-          repository repo[1]
-          enable_submodules true
-          enable_checkout false
-          action :sync
-          user username
-        end
+  directory "#{homepath.call}/.vim/bundle" do
+    owner username
+    mode 00755
+    recursive true
+  end
+
+  node['dotfiles']['vim']['bundle'].each do |bundles|
+    bundles.each do |name, uri|
+      git "#{homepath.call}/.vim/bundle/#{name}" do
+        repository uri
+        enable_submodules true
+        enable_checkout false
+        action :sync
+        user username
       end
     end
   end
@@ -52,22 +51,23 @@ node['dotfiles']['vimusers'].each do |username|
     action :create
   end
 
-  remote_file "#{homepath.call}/.vim/colors/Tomorrow-Night-Eighties.vim" do
-      source "https://raw.githubusercontent.com/chriskempson/tomorrow-theme/master/vim/colors/Tomorrow-Night-Eighties.vim"
-      mode 00755
-      owner username
-      action :create_if_missing
+  node['dotfiles']['vim']['colors'].each do |colors|
+    colors.each do |name, uri|
+      remote_file "#{homepath.call}/.vim/colors/#{name}.vim" do
+        source uri
+        mode 00644
+        owner username
+        action :create_if_missing
+      end
+    end
   end
-  
-  remote_file "#{homepath.call}/.vim/colors/base16-ocean.vim" do
-      source "https://raw.githubusercontent.com/chriskempson/base16-vim/master/colors/base16-ocean.vim"
-      mode 00755
-      owner username
-      action :create_if_missing
-  end
-  
+
   template "#{homepath.call}/.vimrc" do
     source "vimrc.erb"
     owner username
+    variables(
+      'background' => node['dotfiles']['vim']['vimrc']['background'],
+      'colorscheme' => node['dotfiles']['vim']['vimrc']['colorscheme']
+    )
   end
 end

--- a/templates/default/vimrc.erb
+++ b/templates/default/vimrc.erb
@@ -2,16 +2,15 @@ execute pathogen#infect()
 syntax on
 filetype plugin indent on
 set pastetoggle=<F2>
-colorscheme Tomorrow-Night-Eighties
+<% if @background -%>
+set background=<%= @background %>
+<% end -%>
+colorscheme <%= @colorscheme %>
 set number
 
 nmap <silent> <F3> :NERDTreeToggle<CR>
-
 
 if has("autocmd")
   au BufReadPost * if line("'\"") > 0 && line("'\"") <= line("$")
     \| exe "normal! g'\"" | endif
 endif
-
-
-


### PR DESCRIPTION
This change was prompted by wanting to use the [Solarized] (http://ethanschoonover.com/solarized) colour scheme within [vim] (https://github.com/altercation/vim-colors-solarized).

It is now possible to install and use the Solarized Dark colour scheme for vim via [kitchenplan] (http://kitchenplan.github.io/kitchenplan/) like so:
```
attributes:
    dotfiles:
        vim:
            bundle:
                - colors-solarized: git://github.com/altercation/vim-colors-solarized.git
            colors:
                - solarized: https://raw.githubusercontent.com/altercation/solarized/master/vim-colors-solarized/colors/solarized.vim
            vimrc:
                background: dark
                colorscheme: solarized
```